### PR TITLE
feature: Added new parameters to disambiguate_triples

### DIFF
--- a/src/godel/models.py
+++ b/src/godel/models.py
@@ -1,5 +1,6 @@
 from typing import Union, Dict, Literal
 
 DisambiguationTripleDict = Dict[str, Union[str, 'DisambiguationTripleDict']]
+PredicateWeightDict = Dict[str, float]
 
 DisambiguationValidationStatus = Literal["ACCEPTED", "REJECTED", "PENDING", "INVALID", "PAUSED"]


### PR DESCRIPTION
These new parameters allow establishing custom weights when calculating the predicate distance. Also, they allow to use the same call to perform disambiguation against golden.com instead of the protocol.