### PR TITLE
add call_id to disambiguate call

### DIFF
--- a/src/godel/api.py
+++ b/src/godel/api.py
@@ -465,6 +465,7 @@ class GoldenAPI:
                 }
               ) {
                 errors
+                call_id
                 entities {
                   name
                   distance


### PR DESCRIPTION
call_id is newly available on calls to disambiguate_triples.